### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 
 real-time, in-app notifications and admin for web and mobile via the command line. [see it in action](http://holler.bitpshr.net)
 
-##Usage
+## Usage
 Sending notifications with Holler is as easy as four steps:
 
-###1. Install a module
+### 1. Install a module
 Holler is built with <a href="http://nodejs.org/">Node</a> and is distributed as an <a href="http://npmjs.org">npm</a> module. If you don't have Node yet, <a href="http://nodejs.org/">install the hell out of it</a>. Next we just install holler:
 ```console
 npm install holler -g
 ```
 
-###2. Include Holler
+### 2. Include Holler
 
 **New!** Be sure to include the <code>holler.css</code> stylesheet as of v1.9.0:
 ```html
@@ -30,13 +30,13 @@ On the client, Holler can be easily configured to use a specific host and port r
 <script type="text/javascript" src="PATH/TO/holler-client.min.js"></script>
 ```
 
-###3. Start a server
+### 3. Start a server
 The server can be started with an optional port. If no port is specified, it will be defaulted to 1337.
 ```console 
 holler-server 1337
 ```
 
-###4. Holler stuff
+### 4. Holler stuff
 Show notifications to all users currently using your app in real-time using <code>holler.js</code>. Notifications use <a href="http://fabien-d.github.com/alertify.js/">Alertify</a> so they look nice and sexy.
 * Log Messages
 
@@ -73,7 +73,7 @@ You can also redirect the current page to a new url. Again, all users using the 
 holler http://yourServerUrl:port redirect http://someOtherUrl
 ```
 
-##Contributing
+## Contributing
 Holler.js uses [Grunt](http://gruntjs.com) for file linting and uglification. To start contributing, first make sure [node](http://nodejs.org) is installed. Then:
 
 ```bash
@@ -87,5 +87,5 @@ holler-server
 holler http://127.0.0.1:1337 log "foobar"
 ```
 
-##License
+## License
 [WTFPL](http://sam.zoy.org/wtfpl/)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
